### PR TITLE
add check if `source` is function, then thenify it

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ module.exports = function (source, destination, methods) {
     methods = Object.keys(source)
   }
 
+  if (typeof source === 'function') destination = thenify(source)
+
   methods.forEach(function (name) {
     // promisify only if it's a function
     if (typeof source[name] === 'function') destination[name] = thenify(name, source[name])


### PR DESCRIPTION
eg `got` package

``` js
var got = require('got');
var thenifyAll = require('thenify-all');

module.exports = thenifyAll(got);
```

then if try `got(url).then()` will throw that `then` is undefined and `got.get(url).then()` will work.
