### PR TITLE
Travis-ci: added support for ppc64le & updated latest nodejs versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 node_js:
-- "0.8"
-- "0.10"
-- "0.11"
+  - "13"
+  - "14"
+  - "15"
 language: node_js
+arh:
+  - amd64
+  - ppc64le
 script: "npm run-script test-travis"
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"


### PR DESCRIPTION
Hi,

I had added ppc64le(Linux on Power) architecture and update latest nodejs versions support on Travis-CI in the PR and looks like its been successfully added.

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Regards,
Devendra